### PR TITLE
Make compatible with 3.2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         ],
     },
     install_requires=[
-        'fabric==1.13.1',
+        'fabric==1.8.3',
         'cloudify==3.2.1'
     ]
 )


### PR DESCRIPTION
With fabric 1.13.1, pkg_resources is raising errors due to fabric 1.8.3 being installed where 1.13.1 is required (or similar errors, reversed, if 1.13.1 is then installed).